### PR TITLE
Use `modifyIORef'` instead of `modifyIORef`

### DIFF
--- a/src/Language/Jsonnet/Eval/Monad.hs
+++ b/src/Language/Jsonnet/Eval/Monad.hs
@@ -77,7 +77,7 @@ instance Fresh (EvalM a) where
   fresh (Fn s _) = EvalM $ do
     ref <- view gen
     n <- liftIO $ readIORef ref
-    liftIO $ modifyIORef ref (+ 1)
+    liftIO $ modifyIORef' ref (+ 1)
     return $ (Fn s n)
   fresh nm@(Bn {}) = return nm
 


### PR DESCRIPTION
As per the documentation for `Data.IORef`, `modifyIORef'` is a strict version of `modifyIORef`: https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-IORef.html#v:modifyIORef-39-