### PR TITLE
Add external variable support

### DIFF
--- a/benchmarks/Bench.hs
+++ b/benchmarks/Bench.hs
@@ -13,7 +13,7 @@ import Prettyprinter (Pretty, pretty)
 render :: Pretty a => a -> LBS.ByteString
 render = encodeUtf8 . pack . show . pretty
 
-conf = Config ""
+conf = Config "" mempty
 
 eval :: Expr -> IO LBS.ByteString
 eval expr = do

--- a/benchmarks/Bench.hs
+++ b/benchmarks/Bench.hs
@@ -7,8 +7,8 @@ import Language.Jsonnet
 import Language.Jsonnet.Core (Core)
 import Language.Jsonnet.Syntax.Annotated (Expr)
 import Language.Jsonnet.TH.QQ
-import Test.Tasty.Bench
 import Prettyprinter (Pretty, pretty)
+import Test.Tasty.Bench
 
 render :: Pretty a => a -> LBS.ByteString
 render = encodeUtf8 . pack . show . pretty

--- a/jsonnet.cabal
+++ b/jsonnet.cabal
@@ -100,7 +100,9 @@ executable hs-jsonnet
       aeson,
       base,
       bytestring,
+      containers,
       text,
+      megaparsec,
       mtl,
       prettyprinter,
       optparse-applicative >= 0.16.1 && < 0.17
@@ -119,6 +121,7 @@ test-suite jsonnet-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base
+    , containers
     , prettyprinter
     , jsonnet
     , mtl

--- a/src/Language/Jsonnet.hs
+++ b/src/Language/Jsonnet.hs
@@ -24,6 +24,7 @@ module Language.Jsonnet
     evaluate,
     desugar,
     ExtVar (..),
+    ExtVarType (..),
     interpretExtVar,
     constructExtVars,
   )
@@ -125,13 +126,18 @@ std = do
     core = decode $(mkStdlib)
     mergeObjects x y = whnfPrim (BinOp Add) [Pos x, Pos y]
 
-data ExtVar
-  = ExtStr !Text
-  | ExtCode !Text
+data ExtVar = ExtVar
+  { extVarType :: !ExtVarType
+  , extVarText :: !Text
+  }
+
+data ExtVarType
+  = ExtStr
+  | ExtCode
 
 interpretExtVar :: ExtVar -> IO Value
-interpretExtVar (ExtStr s) = pure $ VStr s
-interpretExtVar (ExtCode s) =
+interpretExtVar (ExtVar ExtStr s) = pure $ VStr s
+interpretExtVar (ExtVar ExtCode s) =
   either dieError pure =<< interpretToValue s
   where
     interpretToValue :: Text -> IO (Either Error Value)

--- a/src/Language/Jsonnet.hs
+++ b/src/Language/Jsonnet.hs
@@ -79,8 +79,8 @@ newtype JsonnetM a = JsonnetM
     )
 
 data Config = Config
-  { fname :: FilePath
-  , extVars :: ExtVars
+  { fname :: FilePath,
+    extVars :: ExtVars
   }
 
 runJsonnetM :: Config -> JsonnetM a -> IO (Either Error a)

--- a/src/Language/Jsonnet.hs
+++ b/src/Language/Jsonnet.hs
@@ -136,7 +136,7 @@ interpretExtVar (ExtCode s) =
   where
     interpretToValue :: Text -> IO (Either Error Value)
     interpretToValue =
-      runJsonnetM (Config "External variable" (ExtVars mempty))
+      runJsonnetM (Config "External variable" mempty)
         . (parse >=> check >=> desugar >=> evaluateToValue)
 
     evaluateToValue :: Core -> JsonnetM Value

--- a/src/Language/Jsonnet/Error.hs
+++ b/src/Language/Jsonnet/Error.hs
@@ -38,6 +38,7 @@ data EvalError
   | IndexOutOfBounds Scientific
   | DivByZero
   | VarNotFound Text
+  | ExtVarNotFound Text
   | AssertionFailed Text
   | TooManyArgs Int
   | ParamNotBound Text

--- a/src/Language/Jsonnet/Pretty.hs
+++ b/src/Language/Jsonnet/Pretty.hs
@@ -166,6 +166,10 @@ instance Pretty EvalError where
       pretty "variable"
         <+> squotes (pretty $ show v)
         <+> pretty "is not defined"
+    ExtVarNotFound v ->
+      pretty "external variable"
+        <+> squotes (pretty v)
+        <+> pretty "is not defined"
     AssertionFailed e ->
       pretty "assertion failed:" <+> pretty e
     StdError e -> pretty e

--- a/src/Language/Jsonnet/Std/Lib.hs
+++ b/src/Language/Jsonnet/Std/Lib.hs
@@ -28,8 +28,8 @@ import qualified Data.ByteString as B
 import Data.Foldable (foldrM)
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as H
-import qualified Data.Map.Strict as M
 import qualified Data.List as L (intercalate, sort)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T

--- a/src/Language/Jsonnet/Std/Lib.hs
+++ b/src/Language/Jsonnet/Std/Lib.hs
@@ -28,6 +28,7 @@ import qualified Data.ByteString as B
 import Data.Foldable (foldrM)
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as H
+import qualified Data.Map.Strict as M
 import qualified Data.List as L (intercalate, sort)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -49,8 +50,8 @@ import Prelude hiding (length)
 import qualified Prelude as P (length)
 
 -- | Jsonnet standard library built-in methods
-std :: Value
-std = VObj $ H.fromList $ map f xs
+std :: ExtVars -> Value
+std extVars = VObj $ H.fromList $ map f xs
   where
     f = \(k, v) -> (k, VField (VStr k) v v Hidden)
     xs =
@@ -82,8 +83,12 @@ std = VObj $ H.fromList $ map f xs
         ("join", inj intercalate),
         ("objectHasEx", inj objectHasEx),
         ("objectFieldsEx", inj objectFieldsEx),
-        ("parseJson", inj (JSON.decodeStrict @Value))
+        ("parseJson", inj (JSON.decodeStrict @Value)),
+        ("extVar", inj (lookupExtVar extVars))
       ]
+
+lookupExtVar :: ExtVars -> Text -> Eval Value
+lookupExtVar (ExtVars extVars) s = liftMaybe (ExtVarNotFound s) (M.lookup s extVars)
 
 intercalate :: Value -> [Value] -> Eval Value
 intercalate sep arr = go sep (filter null arr)

--- a/src/Language/Jsonnet/Value.hs
+++ b/src/Language/Jsonnet/Value.hs
@@ -15,6 +15,7 @@ import Control.Lens (view)
 import Control.Monad.Except
 import Data.HashMap.Lazy (HashMap)
 import Data.IORef
+import Data.Map.Strict (Map)
 import Data.Scientific
 import Data.Text (Text)
 import Data.Vector (Vector)
@@ -27,6 +28,8 @@ import Language.Jsonnet.Pretty ()
 type Eval = EvalM Value
 
 type Env = Ctx Value
+
+newtype ExtVars = ExtVars (Map Text Value)
 
 data Value
   = VNull

--- a/src/Language/Jsonnet/Value.hs
+++ b/src/Language/Jsonnet/Value.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- |
 -- Module                  : Language.Jsonnet.Value
@@ -30,6 +32,7 @@ type Eval = EvalM Value
 type Env = Ctx Value
 
 newtype ExtVars = ExtVars (Map Text Value)
+                deriving newtype (Semigroup, Monoid)
 
 data Value
   = VNull

--- a/src/Language/Jsonnet/Value.hs
+++ b/src/Language/Jsonnet/Value.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- Module                  : Language.Jsonnet.Value
@@ -32,7 +32,7 @@ type Eval = EvalM Value
 type Env = Ctx Value
 
 newtype ExtVars = ExtVars (Map Text Value)
-                deriving newtype (Semigroup, Monoid)
+  deriving newtype (Semigroup, Monoid)
 
 data Value
   = VNull

--- a/test/Language/Jsonnet/Test/Golden.hs
+++ b/test/Language/Jsonnet/Test/Golden.hs
@@ -44,7 +44,7 @@ run conf = do
 extVars :: ExtVars
 extVars = ExtVars $ M.fromList
   [ ("var1", VStr "test"),
-    ("var2", unsafePerformIO $ interpretExtVar (ExtCode "{x:1,y:2}"))
+    ("var2", unsafePerformIO $ interpretExtVar (ExtVar ExtCode (Inline "{x:1,y:2}")))
   ]
 
 goldenTests :: IO TestTree

--- a/test/Language/Jsonnet/Test/Golden.hs
+++ b/test/Language/Jsonnet/Test/Golden.hs
@@ -42,10 +42,12 @@ run conf = do
 
 -- Adapted from the C++ test suite
 extVars :: ExtVars
-extVars = ExtVars $ M.fromList
-  [ ("var1", VStr "test"),
-    ("var2", unsafePerformIO $ interpretExtVar (ExtVar ExtCode (Inline "{x:1,y:2}")))
-  ]
+extVars =
+  ExtVars $
+    M.fromList
+      [ ("var1", VStr "test"),
+        ("var2", unsafePerformIO $ interpretExtVar (ExtVar ExtCode (Inline "{x:1,y:2}")))
+      ]
 
 goldenTests :: IO TestTree
 goldenTests = do

--- a/test/Language/Jsonnet/Test/Golden.hs
+++ b/test/Language/Jsonnet/Test/Golden.hs
@@ -9,11 +9,12 @@ import Control.Monad
 import Control.Monad.Except
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T (readFile)
 import Data.Text.Lazy
 import Data.Text.Lazy.Encoding (encodeUtf8)
-import Language.Jsonnet
+import Language.Jsonnet hiding (extVars)
 import Language.Jsonnet.Annotate
 import Language.Jsonnet.Desugar
 import Language.Jsonnet.Error
@@ -25,6 +26,7 @@ import Language.Jsonnet.Std.TH (mkStdlib)
 import Language.Jsonnet.Value
 import Prettyprinter (Pretty, pretty)
 import System.FilePath (replaceExtension, takeBaseName)
+import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.Golden (findByExtension, goldenVsString)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
@@ -38,6 +40,13 @@ run conf = do
   outp <- interpret conf prog
   pure (either render render outp)
 
+-- Adapted from the C++ test suite
+extVars :: ExtVars
+extVars = ExtVars $ M.fromList
+  [ ("var1", VStr "test"),
+    ("var2", unsafePerformIO $ interpretExtVar (ExtCode "{x:1,y:2}"))
+  ]
+
 goldenTests :: IO TestTree
 goldenTests = do
   jsonnetFiles <- findByExtension [".jsonnet"] "./test/golden"
@@ -47,7 +56,7 @@ goldenTests = do
       [ goldenVsString
           (takeBaseName jsonnetFile) -- test name
           goldenFile -- golden file path
-          (run $ Config jsonnetFile)
+          (run $ Config jsonnetFile extVars)
         | jsonnetFile <- jsonnetFiles,
           let goldenFile = replaceExtension jsonnetFile ".golden"
       ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -16,4 +16,8 @@ main = do
   defaultMain $
     testGroup
       "tests"
-      [testRoundtripGroup, goldenTests']
+      -- Roundtrip test is temporarily commented out, see:
+      -- https://github.com/moleike/haskell-jsonnet/issues/45
+      [ -- testRoundtripGroup,
+        goldenTests'
+      ]

--- a/test/golden/stdlib.jsonnet
+++ b/test/golden/stdlib.jsonnet
@@ -395,6 +395,12 @@ std.assertEqual(std.reverse([[1, 2, 3]]), [[1, 2, 3]]) &&
 //    std.assertEqual(std.thisFile, 'stdlib.jsonnet')
 //) &&
 
+std.assertEqual(std.extVar('var1'), 'test') &&
+
+std.assertEqual(std.extVar('var2'), { x: 1, y: 2 }) &&
+// std.assertEqual(std.toString(std.extVar('var2')), '{"x": 1, "y": 2}') &&
+// std.assertEqual(std.extVar('var2') { x+: 2 }.x, 3) &&
+
 local some_toml = {
   key: 'value',
   simple: { t: 5 },


### PR DESCRIPTION
Closes #38 

As far as the Jsonnet spec goes, it seems like only the `--ext-str` flag is necessary, however I am trying to provide as much of the features from reference implementations as possible. Currently this PR adds:

- [x] `--ext-str` CLI option to provide string variables
- [x] `--ext-code` CLI option to provide external code blocks
- [x] Reading from the environment variables when the value part is missing from the `--ext-str`/`--ext-code`
- [x] `--ext-*-file` variants of the options to read the input from files

I have also added the related golden tests from the C++ implementation's test suite, though some of them are not working because of the reasons that I believe to be unrelated to the external variables implementation. I have left those cases commented out.

Please let me know what you think! If this seems to be going in the right direction, I am going to be working on implementing the rest of the features as well.