### PR TITLE
Fix roundtrip test

### DIFF
--- a/src/Language/Jsonnet/Common.hs
+++ b/src/Language/Jsonnet/Common.hs
@@ -37,17 +37,6 @@ import Unbound.Generics.LocallyNameless.TH (makeClosedAlpha)
 n2s :: Name a -> Text
 n2s = T.pack . name2String
 
-data Quoting = Quoted | Unquoted
-  deriving
-    ( Show,
-      Eq,
-      Ord,
-      Generic,
-      Typeable,
-      Data,
-      Binary
-    )
-
 data Literal
   = Null
   | Bool Bool

--- a/src/Language/Jsonnet/Desugar.hs
+++ b/src/Language/Jsonnet/Desugar.hs
@@ -74,7 +74,7 @@ alg outermost = \case
   EIf c t -> desugarIfElse c t (CLit Null)
   EArr e -> CArr e
   EObj {..} -> desugarObj outermost locals fields
-  ELookup e1 e2 -> desugarLookup e1 e2
+  ELookup e1 i -> desugarLookup e1 (CLit (String (T.pack i)))
   EIndex e1 e2 -> desugarLookup e1 e2
   EErr e -> desugarErr e
   EAssert e -> desugarAssert e

--- a/src/Language/Jsonnet/Desugar.hs
+++ b/src/Language/Jsonnet/Desugar.hs
@@ -59,7 +59,7 @@ alg :: Bool -> ExprF Core -> Core
 alg outermost = \case
   ENull -> CLit Null
   EBool b -> CLit (Bool b)
-  EStr s _ -> CLit (String s)
+  EStr s -> CLit (String s)
   ENum n -> CLit (Number n)
   EIdent i -> CVar (s2n i)
   EFun ps e -> desugarFun ps e
@@ -168,7 +168,8 @@ desugarObjComp EField {..} comp locals =
             { key = key',
               value = value',
               visibility,
-              override
+              override,
+              computed
             }
         )
     bnds = NE.zip (fmap var comp) xs

--- a/src/Language/Jsonnet/Parser.hs
+++ b/src/Language/Jsonnet/Parser.hs
@@ -456,7 +456,15 @@ indexP :: Parser (Expr' -> Expr')
 indexP = flip mkIndex <$> brackets exprP
 
 lookupP :: Parser (Expr' -> Expr')
-lookupP = flip mkLookup <$> (symbol "." *> unquoted) <?> "."
+lookupP = flip mkLookup <$> (symbol "." *> annotatedIdent) <?> "."
+  where
+    annotatedIdent :: Parser (Ident, SrcSpan)
+    annotatedIdent = do
+      begin <- getSourcePos
+      res <- identifier
+      end <- getSourcePos
+      let sourceSpan = SrcSpan begin end
+      pure (res, sourceSpan)
 
 -- arguments are many postional followed by many named
 -- just like Python

--- a/src/Language/Jsonnet/Pretty.hs
+++ b/src/Language/Jsonnet/Pretty.hs
@@ -348,7 +348,7 @@ ppExpr = \case
   EErr a -> perror <+> parens a
   EAssert (Assert c m e) -> passert <+> c <> ppMaybeDoc ((colon <>) <$> m) <> semi <+> e
   EIndex a b -> parens a <> brackets b
-  ELookup a b -> enclose a b dot
+  ELookup a i -> enclose a (pretty i) dot
   EUnyOp o a -> parens (pretty o <> a)
   EBinOp o a b -> parens (parens a <+> pretty o <+> parens b)
   ESlice a b e s -> parens a <> bracketSep colon (ppMaybeDoc <$> [b, e, s])

--- a/src/Language/Jsonnet/Pretty.hs
+++ b/src/Language/Jsonnet/Pretty.hs
@@ -334,8 +334,7 @@ ppExpr = \case
   ENull -> pnull
   EBool True -> ptrue
   EBool False -> pfalse
-  EStr s Unquoted -> pretty s
-  EStr s Quoted  -> squotes (pretty s)
+  EStr s -> squotes (pretty s)
   ENum n -> ppNumber n
   EFun ps e -> ppFun ps e
   EApply a args -> parens a <> ppArgs args

--- a/src/Language/Jsonnet/Syntax.hs
+++ b/src/Language/Jsonnet/Syntax.hs
@@ -64,7 +64,7 @@ data ExprF a
   = ENull
   | EBool Bool
   | ENum Scientific
-  | EStr Text Quoting
+  | EStr Text
   | EIdent Ident
   | EFun [Param a] a
   | EApply a (Args a)
@@ -146,10 +146,10 @@ mkIntF = InL . ENum . fromIntegral
 mkFloatF :: Scientific -> ExprF' a
 mkFloatF = InL . ENum
 
-mkTextF :: Text -> Quoting -> ExprF' a
-mkTextF s = InL . EStr s
+mkTextF :: Text -> ExprF' a
+mkTextF = InL . EStr
 
-mkStrF :: String -> Quoting -> ExprF' a
+mkStrF :: String -> ExprF' a
 mkStrF s = mkTextF (T.pack s)
 
 mkBoolF :: Bool -> ExprF' a

--- a/src/Language/Jsonnet/Syntax.hs
+++ b/src/Language/Jsonnet/Syntax.hs
@@ -83,7 +83,7 @@ data ExprF a
       }
   | EArr [a]
   | EErr a
-  | ELookup a a
+  | ELookup a Ident
   | EIndex a a
   | EAssert (Assert a)
   | EIf a a
@@ -173,7 +173,7 @@ mkIfElseF c a = InL . EIfElse c a
 mkLocalF :: NonEmpty (Ident, a) -> a -> ExprF' a
 mkLocalF n = InL . ELocal n
 
-mkLookupF :: a -> a -> ExprF' a
+mkLookupF :: a -> Ident -> ExprF' a
 mkLookupF e = InL . ELookup e
 
 mkIndexF :: a -> a -> ExprF' a

--- a/src/Language/Jsonnet/Syntax/Annotated.hs
+++ b/src/Language/Jsonnet/Syntax/Annotated.hs
@@ -29,9 +29,9 @@ mkApply a@(Fix (AnnF _ ann)) args =
 --mkApply a@(Fix (AnnF _ ann)) b =
 --  Fix $ AnnF (InL $ EApply a b) (fold1 (ann <| fmap attrib (fromList b)))
 
-mkLookup :: Expr' -> Expr' -> Expr'
-mkLookup a@(Fix (AnnF _ ann1)) b@(Fix (AnnF _ ann2)) =
-  Fix $ AnnF (InL $ ELookup a b) (ann1 <> ann2)
+mkLookup :: Expr' -> (Ident, SrcSpan) -> Expr'
+mkLookup a@(Fix (AnnF _ ann1)) (ident, ann2) =
+  Fix $ AnnF (InL $ ELookup a ident) (ann1 <> ann2)
 
 mkIndex :: Expr' -> Expr' -> Expr'
 mkIndex a@(Fix (AnnF _ ann1)) b@(Fix (AnnF _ ann2)) =

--- a/test/Language/Jsonnet/Test/Roundtrip.hs
+++ b/test/Language/Jsonnet/Test/Roundtrip.hs
@@ -70,7 +70,7 @@ genIndex :: Gen (Fix ExprF')
 genIndex = Gen.subterm2 genExpr genExpr (\a b -> Fix (mkIndexF a b))
 
 genLookup :: Gen (Fix ExprF')
-genLookup = Gen.subterm2 genIdent genUnquoted (\a b -> Fix (mkLookupF a b))
+genLookup = Fix <$> (mkLookupF <$> genIdent <*> genString)
 
 genAssert :: Gen (Fix ExprF')
 genAssert =

--- a/test/Language/Jsonnet/Test/Roundtrip.hs
+++ b/test/Language/Jsonnet/Test/Roundtrip.hs
@@ -90,10 +90,7 @@ genLocal =
         )
 
 genLitStr :: Gen (Fix ExprF')
-genLitStr = Fix <$> (mkTextF <$> genText <*> pure Quoted)
-
-genUnquoted :: Gen (Fix ExprF')
-genUnquoted = Fix <$> (mkTextF <$> genText <*> pure Unquoted)
+genLitStr = Fix <$> (mkTextF <$> genText)
 
 genLiteral :: Gen (Fix ExprF')
 genLiteral =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -16,8 +16,6 @@ main = do
   defaultMain $
     testGroup
       "tests"
-      -- Roundtrip test is temporarily commented out, see:
-      -- https://github.com/moleike/haskell-jsonnet/issues/45
-      [ -- testRoundtripGroup,
+      [ testRoundtripGroup,
         goldenTests'
       ]


### PR DESCRIPTION
Closes #45

As discussed in the comments of #45, the lookup expression did not conform to the Jsonnet specification. Interestingly enough, the roundtrip test seemed to be fixed on its own after I have changed the definition of the lookup expression. Still, I have also removed the unquoted strings altogether, since they weren't really needed anymore. However, I am not 100% confident in the potential implications of this change, so it would be a good idea to review this thoroughly before merging.