### PR TITLE
Emit prettified JSON by default

### DIFF
--- a/jsonnet.cabal
+++ b/jsonnet.cabal
@@ -98,7 +98,6 @@ executable hs-jsonnet
   build-depends:
       jsonnet,
       aeson,
-      aeson-pretty,
       base,
       bytestring,
       containers,

--- a/jsonnet.cabal
+++ b/jsonnet.cabal
@@ -98,6 +98,7 @@ executable hs-jsonnet
   build-depends:
       jsonnet,
       aeson,
+      aeson-pretty,
       base,
       bytestring,
       containers,


### PR DESCRIPTION
This PR makes the JSON output of the executable prettified by default, with the option of preserving the old behaviour through a new `--compact` flag.

I realized go-jsonnet compiler produced pretty JSON output. I thought it was a saner default as well, so here it is.