### PR TITLE
Enable warnings

### DIFF
--- a/jsonnet.cabal
+++ b/jsonnet.cabal
@@ -35,9 +35,16 @@ common common-extensions
       DerivingVia
       RecordWildCards
 
+common common-warnings
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+    -Wno-unused-do-bind -Wunused-packages
+
 library
   import:
       common-extensions
+    , common-warnings
   exposed-modules:
       Language.Jsonnet
     , Language.Jsonnet.Error
@@ -95,6 +102,7 @@ library
 executable hs-jsonnet
   import:
       common-extensions
+    , common-warnings
   main-is: Main.hs
   autogen-modules:
       Paths_jsonnet
@@ -118,6 +126,7 @@ executable hs-jsonnet
 test-suite jsonnet-test
   import:
       common-extensions
+    , common-warnings
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
@@ -148,6 +157,7 @@ test-suite jsonnet-test
 benchmark jsonnet-bench
   import:
       common-extensions
+    , common-warnings
   main-is: Bench.hs
   type: exitcode-stdio-1.0
   hs-source-dirs:

--- a/jsonnet.cabal
+++ b/jsonnet.cabal
@@ -86,12 +86,10 @@ library
       mtl                           >= 2.2.2 && < 2.4,
       vector                        >= 0.12.3 && < 0.14,
       prettyprinter                 >= 1.7.0 && < 1.8,
-      deriving-compat               >= 0.5.10 && < 0.7,
       directory                     >= 1.3.6 && < 1.4,
       filepath                      >= 1.4.2 && < 1.6,
       exceptions                    >= 0.10.4 && < 0.11,
       lens                          >= 5.0.1 && < 5.4,
-      semigroupoids                 >= 5.3.5 && < 6.1,
       megaparsec                    >= 9.5 && < 9.8,
       parser-combinators            >= 1.2.1 && < 1.4,
       unbound-generics              >= 0.4.3 && < 0.5,
@@ -116,11 +114,8 @@ executable hs-jsonnet
       aeson,
       base,
       bytestring,
-      containers,
       text,
       megaparsec,
-      mtl,
-      prettyprinter,
       optparse-applicative >= 0.16.1 && < 0.19
 
 test-suite jsonnet-test

--- a/jsonnet.cabal
+++ b/jsonnet.cabal
@@ -137,15 +137,12 @@ test-suite jsonnet-test
     , containers
     , prettyprinter
     , jsonnet
-    , mtl
     , text
     , filepath
     , data-fix
     , bytestring
     , tasty
     , tasty-golden
-    , tasty-expected-failure
-    , tasty-hunit
     , hedgehog
     , tasty-hedgehog
 

--- a/src/Language/Jsonnet.hs
+++ b/src/Language/Jsonnet.hs
@@ -25,7 +25,6 @@ module Language.Jsonnet
   )
 where
 
-import Control.Exception (throwIO)
 import Control.Monad ((>=>), (<=<))
 import Control.Monad.Fix (MonadFix)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
@@ -33,14 +32,10 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import qualified Data.Aeson as JSON
 import Data.Binary (decode)
-import Data.Functor.Identity
-import Data.Functor.Sum
 import qualified Data.Map.Lazy as M
 import Data.Map.Strict (singleton)
 import Data.Text (Text)
 import qualified Data.Text.IO as T
-import Debug.Trace
-import Language.Jsonnet.Annotate
 import qualified Language.Jsonnet.Check as Check
 import Language.Jsonnet.Common
 import Language.Jsonnet.Core
@@ -49,12 +44,11 @@ import Language.Jsonnet.Error
 import Language.Jsonnet.Eval
 import Language.Jsonnet.Eval.Monad
 import qualified Language.Jsonnet.Parser as Parser
-import Language.Jsonnet.Pretty ()
+import Language.Jsonnet.Pretty (prettyError)
 import qualified Language.Jsonnet.Std.Lib as Lib
 import Language.Jsonnet.Std.TH (mkStdlib)
 import Language.Jsonnet.Syntax.Annotated
 import Language.Jsonnet.Value
-import Prettyprinter (pretty)
 import System.Exit (die)
 
 newtype JsonnetM a = JsonnetM
@@ -157,7 +151,7 @@ interpretExtVar = \case
       JsonnetM $ lift $ ExceptT $ runEvalM env (whnf expr)
 
     dieError :: Error -> IO a
-    dieError = die . show . pretty
+    dieError = die . show . prettyError
 
 constructExtVars :: [(Text, ExtVar)] -> IO ExtVars
 constructExtVars = fmap (ExtVars . M.fromList) . traverse interpretExtVarPair

--- a/src/Language/Jsonnet/Annotate.hs
+++ b/src/Language/Jsonnet/Annotate.hs
@@ -20,6 +20,8 @@ type AnnF f a = Product (Const a) f
 -- | Annotated fixed-point type. Equivalent to CoFree f a
 type Ann f a = Fix (AnnF f a)
 
+{-# COMPLETE AnnF #-}
+pattern AnnF :: f a -> ann -> AnnF f ann a
 pattern AnnF f a = Pair (Const a) f
 
 annMap :: Functor f => (a -> b) -> Ann f a -> Ann f b

--- a/src/Language/Jsonnet/Check.hs
+++ b/src/Language/Jsonnet/Check.hs
@@ -9,16 +9,13 @@ module Language.Jsonnet.Check where
 
 import Control.Monad.Except
 import Data.Fix
-import Data.Functor.Identity
-import Data.List
+import Data.List qualified as List
 import qualified Data.List.NonEmpty as NE
 import Language.Jsonnet.Annotate
 import Language.Jsonnet.Common hiding (span)
-import Language.Jsonnet.Core
 import Language.Jsonnet.Error
 import Language.Jsonnet.Parser.SrcSpan
 import Language.Jsonnet.Syntax
-import Unbound.Generics.LocallyNameless
 
 type Check = ExceptT Error IO
 
@@ -32,17 +29,17 @@ check = foldFixM alg
       _ -> pure ()
     checkLocal names = case dups names of
       [] -> pure ()
-      ((x:xs) : _) -> throwError $ DuplicateBinding x
+      ((x:_) : _) -> throwError $ DuplicateBinding x
     checkFun names = case dups names of
       [] -> pure ()
-      ((x:xs) : _) -> throwError $ DuplicateParam x
+      ((x:_) : _) -> throwError $ DuplicateParam x
     checkApply args = case f args of
       [] -> pure ()
-      (x : _) -> throwError $ PosAfterNamedParam
+      _ -> throwError $ PosAfterNamedParam
       where
-        f args = filter isPos ns
+        f _ = filter isPos ns
         isPos = \case
           Pos _ -> True
           _ -> False
-        (ps, ns) = span isPos args
-    dups = filter ((> 1) . length) . group . sort
+        (_, ns) = span isPos args
+    dups = filter ((> 1) . length) . List.group . List.sort

--- a/src/Language/Jsonnet/Check.hs
+++ b/src/Language/Jsonnet/Check.hs
@@ -28,11 +28,11 @@ check = foldFixM alg
       EApply _ (Args as _) -> checkApply as
       _ -> pure ()
     checkLocal names = case dups names of
-      [] -> pure ()
       ((x:_) : _) -> throwError $ DuplicateBinding x
+      _ -> pure ()
     checkFun names = case dups names of
-      [] -> pure ()
       ((x:_) : _) -> throwError $ DuplicateParam x
+      _ -> pure ()
     checkApply args = case f args of
       [] -> pure ()
       _ -> throwError $ PosAfterNamedParam

--- a/src/Language/Jsonnet/Common.hs
+++ b/src/Language/Jsonnet/Common.hs
@@ -20,7 +20,6 @@ import qualified Data.Text as T (pack)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic, Generic1)
 import Language.Jsonnet.Parser.SrcSpan (SrcSpan)
-import Text.Show.Deriving (deriveShow1)
 import Unbound.Generics.LocallyNameless (Alpha (..), Name, name2String)
 import Unbound.Generics.LocallyNameless.TH (makeClosedAlpha)
 

--- a/src/Language/Jsonnet/Core.hs
+++ b/src/Language/Jsonnet/Core.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- |
 -- Module                  : Language.Jsonnet.Core
 -- Copyright               : (c) 2020-2021 Alexandre Moreno

--- a/src/Language/Jsonnet/Error.hs
+++ b/src/Language/Jsonnet/Error.hs
@@ -15,7 +15,6 @@ import Data.Void (Void)
 import Language.Jsonnet.Common
 import Language.Jsonnet.Core
 import Language.Jsonnet.Parser.SrcSpan
-import Prettyprinter (Doc)
 import Text.Megaparsec (ParseErrorBundle)
 
 data Error
@@ -27,7 +26,11 @@ data Error
 instance Exception Error
 
 data EvalError
-  = TypeMismatch {expected :: Text, actual :: Text}
+  = TypeMismatch
+      Text
+      -- ^ expected
+      Text
+      -- ^ actual
   | InvalidKey Text
   | DuplicateKey Text
   | NoSuchKey Text

--- a/src/Language/Jsonnet/Eval/Monad.hs
+++ b/src/Language/Jsonnet/Eval/Monad.hs
@@ -79,9 +79,9 @@ instance Fresh (EvalM a) where
   fresh nm@(Bn {}) = return nm
 
 runEvalM :: Ctx a -> EvalM a b -> IO (Either Error b)
-runEvalM ctx e = do
-  gen <- newIORef 0
-  let st = EvalState ctx emptyStack Nothing gen
+runEvalM ctx' e = do
+  gen' <- newIORef 0
+  let st = EvalState ctx' emptyStack Nothing gen'
   (`runReaderT` st) (runExceptT (unEval e))
 
 throwE :: EvalError -> EvalM a b
@@ -94,9 +94,9 @@ withEnv :: Ctx a -> EvalM a b -> EvalM a b
 withEnv = locally ctx . const
 
 pushStackFrame :: (Name Core, Maybe SrcSpan) -> EvalM a b -> EvalM a b
-pushStackFrame (name, span) =
+pushStackFrame (name, span') =
   locally (callStack . scopes) (name :)
-    . locally (callStack . spans) (span :)
+    . locally (callStack . spans) (span' :)
 
 getBacktrace :: EvalM a (Backtrace Core)
 getBacktrace = do
@@ -105,5 +105,5 @@ getBacktrace = do
   pure $
     Backtrace $
       case sequence sp of
-        Just sp -> zipWith StackFrame sc sp
+        Just sp' -> zipWith StackFrame sc sp'
         Nothing -> []

--- a/src/Language/Jsonnet/Parser/SrcSpan.hs
+++ b/src/Language/Jsonnet/Parser/SrcSpan.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |
 -- Module                  : Language.Jsonnet.Parser.SrcSpan

--- a/src/Language/Jsonnet/Pretty.hs
+++ b/src/Language/Jsonnet/Pretty.hs
@@ -17,18 +17,15 @@ import Data.Bool (bool)
 import Data.Fix
 import Data.Functor.Sum
 import Data.Maybe (fromMaybe)
-import qualified Data.HashMap.Lazy as H
 import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Scientific (Scientific (..))
-import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import Data.Text.Lazy.Builder
 import Data.Text.Lazy.Builder.Scientific (scientificBuilder)
 import qualified Data.Vector as V
-import Data.Void (Void)
 import GHC.IO.Exception (IOException (..))
 import Language.Jsonnet.Annotate
 import Language.Jsonnet.Common
@@ -60,8 +57,8 @@ passert = pretty "assert"
 pfor = pretty "for"
 pin = pretty "in"
 
-instance Pretty (Name a) where
-  pretty v = pretty (name2String v)
+prettyName :: Name a -> Doc ann
+prettyName = pretty . name2String
 
 ppNumber :: Scientific -> Doc ann
 ppNumber s
@@ -82,136 +79,133 @@ ppJson i = \case
   JSON.Bool False -> pfalse
   JSON.String s -> ppString (Key.fromText s)
   JSON.Array a -> ppArray a
-  JSON.Object o -> ppObject o
+  JSON.Object o -> ppObject' o
   where
-    encloseSep l r s ds = case ds of
+    encloseSep' l r s ds = case ds of
       [] -> l <> r
       _ -> l <$$> indent i (vcat $ punctuate s ds) <$$> r
-    ppObject o = encloseSep lbrace rbrace comma xs
+    ppObject' o = encloseSep' lbrace rbrace comma xs
       where
         prop (k, v) = ppString k <> colon <+> ppJson i v
         xs = map prop (sortOn fst $ KeyMap.toList o)
-    ppArray a = encloseSep lbracket rbracket comma xs
+    ppArray a = encloseSep' lbracket rbracket comma xs
       where
         xs = map (ppJson i) (V.toList a)
     ppString = pretty . LT.unpack . JSON.encodeToLazyText
 
-instance Pretty JSON.Value where
-  pretty = ppJson 4
+prettySrcSpan :: SrcSpan -> Doc ann
+prettySrcSpan SrcSpan {spanBegin, spanEnd} =
+  pretty (sourceName spanBegin)
+    <> colon
+    <> lc spanBegin spanEnd
+  where
+    lc (SourcePos _ lb cb) (SourcePos _ le ce)
+      | lb == le =
+        pretty (unPos lb) <> colon
+          <> pretty (unPos cb)
+          <> dash
+          <> pretty (unPos ce)
+      | otherwise =
+        pretty (unPos lb) <> colon <> pretty (unPos cb) <> dash
+          <> pretty (unPos le)
+          <> colon
+          <> pretty (unPos ce)
+    dash = pretty '-'
 
-instance Pretty SrcSpan where
-  pretty SrcSpan {spanBegin, spanEnd} =
-    pretty (sourceName spanBegin)
-      <> colon
-      <> lc spanBegin spanEnd
-    where
-      lc (SourcePos _ lb cb) (SourcePos _ le ce)
-        | lb == le =
-          pretty (unPos lb) <> colon
-            <> pretty (unPos cb)
-            <> dash
-            <> pretty (unPos ce)
-        | otherwise =
-          pretty (unPos lb) <> colon <> pretty (unPos cb) <> dash
-            <> pretty (unPos le)
-            <> colon
-            <> pretty (unPos ce)
-      dash = pretty '-'
+prettyParserError :: ParserError -> Doc ann
+prettyParserError (ParseError e) = pretty (errorBundlePretty e)
+prettyParserError (ImportError (IOError _ _ _ desc _ f) sp) =
+  pretty "Parse error:"
+    <+> pretty f
+    <+> parens (pretty desc)
+    <$$> indent 4 (maybe mempty prettySrcSpan sp)
 
-instance Pretty ParserError where
-  pretty (ParseError e) = pretty (errorBundlePretty e)
-  pretty (ImportError (IOError _ _ _ desc _ f) sp) =
-    pretty "Parse error:"
-      <+> pretty f
-      <+> parens (pretty desc)
-      <$$> indent 4 (pretty sp)
+prettyCheckError :: CheckError -> Doc ann
+prettyCheckError = \case
+  DuplicateParam e ->
+    pretty "duplicate parameter"
+      <+> squotes (pretty e)
+  DuplicateBinding e ->
+    pretty "duplicate local var"
+      <+> squotes (pretty e)
+  PosAfterNamedParam ->
+    pretty "positional after named argument"
 
-instance Pretty CheckError where
-  pretty = \case
-    DuplicateParam e ->
-      pretty "duplicate parameter"
-        <+> squotes (pretty e)
-    DuplicateBinding e ->
-      pretty "duplicate local var"
-        <+> squotes (pretty e)
-    PosAfterNamedParam ->
-      pretty "positional after named argument"
+prettyEvalError :: EvalError -> Doc ann
+prettyEvalError = \case
+  TypeMismatch expected actual ->
+    pretty "type mismatch:"
+      <+> pretty "expected"
+      <+> pretty (T.unpack expected)
+      <+> pretty "but got"
+      <+> pretty (T.unpack actual)
+  InvalidKey k ->
+    pretty "invalid key:"
+      <+> pretty k
+  InvalidIndex k ->
+    pretty "invalid index:"
+      <+> pretty k
+  NoSuchKey k ->
+    pretty "no such key:"
+      <+> pretty k
+  IndexOutOfBounds i ->
+    pretty "index out of bounds:"
+      <+> ppNumber i
+  DivByZero ->
+    pretty "divide by zero exception"
+  VarNotFound v ->
+    pretty "variable"
+      <+> squotes (pretty $ show v)
+      <+> pretty "is not defined"
+  ExtVarNotFound v ->
+    pretty "external variable"
+      <+> squotes (pretty v)
+      <+> pretty "is not defined"
+  AssertionFailed e ->
+    pretty "assertion failed:" <+> pretty e
+  StdError e -> pretty e
+  RuntimeError e -> pretty e
+  ParamNotBound s ->
+    pretty "parameter not bound:"
+      <+> pretty (show s)
+  BadParam s ->
+    pretty "function has no parameter"
+      <+> squotes (pretty s)
+  ManifestError e ->
+    pretty "manifest error:"
+      <+> pretty e
+  TooManyArgs n ->
+    pretty "too many args, function has"
+      <+> pretty n
+      <+> pretty "parameter(s)"
 
-instance Pretty EvalError where
-  pretty = \case
-    TypeMismatch {..} ->
-      pretty "type mismatch:"
-        <+> pretty "expected"
-        <+> pretty (T.unpack expected)
-        <+> pretty "but got"
-        <+> pretty (T.unpack actual)
-    InvalidKey k ->
-      pretty "invalid key:"
-        <+> pretty k
-    InvalidIndex k ->
-      pretty "invalid index:"
-        <+> pretty k
-    NoSuchKey k ->
-      pretty "no such key:"
-        <+> pretty k
-    IndexOutOfBounds i ->
-      pretty "index out of bounds:"
-        <+> ppNumber i
-    DivByZero ->
-      pretty "divide by zero exception"
-    VarNotFound v ->
-      pretty "variable"
-        <+> squotes (pretty $ show v)
-        <+> pretty "is not defined"
-    ExtVarNotFound v ->
-      pretty "external variable"
-        <+> squotes (pretty v)
-        <+> pretty "is not defined"
-    AssertionFailed e ->
-      pretty "assertion failed:" <+> pretty e
-    StdError e -> pretty e
-    RuntimeError e -> pretty e
-    ParamNotBound s ->
-      pretty "parameter not bound:"
-        <+> pretty (show s)
-    BadParam s ->
-      pretty "function has no parameter"
-        <+> squotes (pretty s)
-    ManifestError e ->
-      pretty "manifest error:"
-        <+> pretty e
-    TooManyArgs n ->
-      pretty "too many args, function has"
-        <+> pretty n
-        <+> pretty "parameter(s)"
+prettyStackFrame :: StackFrame a -> Doc ann
+prettyStackFrame StackFrame {name, span = span'} =
+  prettySrcSpan span' <+> f (name2String name)
+  where
+    f "top-level" = mempty
+    f x = pretty "function" <+> angles (pretty x)
 
-instance Pretty (StackFrame a) where
-  pretty StackFrame {..} =
-    pretty span <+> f (name2String name)
-    where
-      f "top-level" = mempty
-      f x = pretty "function" <+> angles (pretty x)
+prettyBacktrace :: Backtrace a -> Doc ann
+prettyBacktrace (Backtrace xs) = vcat $ prettyStackFrame <$> xs
 
-instance Pretty (Backtrace a) where
-  pretty (Backtrace xs) = vcat $ pretty <$> xs
+prettyError :: Error -> Doc ann
+prettyError = \case
+  EvalError e bt ->
+    pretty "Runtime error:"
+      <+> prettyEvalError e
+      <$$> indent 2 (prettyBacktrace bt)
+  ParserError e -> prettyParserError e
+  CheckError e sp ->
+    pretty "Static error:"
+      <+> prettyCheckError e
+      <$$> indent 2 (maybe mempty prettySrcSpan sp)
 
-instance Pretty Error where
-  pretty = \case
-    EvalError e bt ->
-      pretty "Runtime error:"
-        <+> pretty e
-        <$$> indent 2 (pretty bt)
-    ParserError e -> pretty e
-    CheckError e sp ->
-      pretty "Static error:"
-        <+> pretty e
-        <$$> indent 2 (pretty sp)
-
-instance Pretty Visibility where
-  pretty = \case
-    Visible -> pretty ":"
-    Hidden -> pretty "::"
-    Forced -> pretty ":::"
+prettyVisibility :: Visibility -> Doc ann
+prettyVisibility = \case
+  Visible -> pretty ":"
+  Hidden -> pretty "::"
+  Forced -> pretty ":::"
 
 commaSep :: [Doc ann] -> Doc ann
 commaSep = concatWith (surround comma)
@@ -225,23 +219,25 @@ parensSep = encloseSep lparen rparen
 braceSep :: Doc ann -> [Doc ann] -> Doc ann
 braceSep = encloseSep lbrace rbrace
 
+ppField :: EField (Doc ann) -> Doc ann
 ppField EField {..} =
-  surround (ppOverride <> pretty visibility) key' value
+  surround (ppOverride <> prettyVisibility visibility) key' value
   where
     ppOverride = pretty (bool "" "+" override)
     key' = bool key (brackets key) computed
 
+ppObject :: [(Ident, Doc ann)] -> [Doc ann] -> Doc ann
 ppObject l o =
   encloseSep
     lbrace
     rbrace
     comma
-    (mcons (ppLocal l) o)
+    (mcons (ppLocal' l) o)
   where
     mcons ma as = maybe as (: as) ma
-    ppLocal :: [(Ident, Doc ann)] -> Maybe (Doc ann)
-    ppLocal [] = Nothing
-    ppLocal xs =
+    ppLocal' :: [(Ident, Doc ann)] -> Maybe (Doc ann)
+    ppLocal' [] = Nothing
+    ppLocal' xs =
       Just $ commaSep ((plocal <+>) . uncurry (surround equals) <$> xs')
       where
         xs' = first pretty <$> xs
@@ -255,34 +251,34 @@ ppLocal xs e =
   where
     xs' = first pretty <$> xs
 
-instance Pretty UnyOp where
-  pretty = \case
-    Compl -> pretty "~"
-    LNot -> pretty "!"
-    Plus -> pretty "+"
-    Minus -> pretty "-"
+prettyUnyOp :: UnyOp -> Doc ann
+prettyUnyOp = \case
+  Compl -> pretty "~"
+  LNot -> pretty "!"
+  Plus -> pretty "+"
+  Minus -> pretty "-"
 
-instance Pretty BinOp where
-  pretty = \case
-    Add -> pretty "+"
-    Sub -> pretty "-"
-    Mul -> pretty "*"
-    Div -> pretty "/"
-    Mod -> pretty "%"
-    Lt -> pretty "<"
-    Le -> pretty "<="
-    Gt -> pretty ">"
-    Ge -> pretty ">="
-    Eq -> pretty "=="
-    Ne -> pretty "!="
-    And -> pretty "&"
-    Or -> pretty "|"
-    Xor -> pretty "^"
-    ShiftL -> pretty "<<"
-    ShiftR -> pretty ">>"
-    LAnd -> pretty "&&"
-    LOr -> pretty "||"
-    In -> pretty "in"
+prettyBinOp :: BinOp -> Doc ann
+prettyBinOp = \case
+  Add -> pretty "+"
+  Sub -> pretty "-"
+  Mul -> pretty "*"
+  Div -> pretty "/"
+  Mod -> pretty "%"
+  Lt -> pretty "<"
+  Le -> pretty "<="
+  Gt -> pretty ">"
+  Ge -> pretty ">="
+  Eq -> pretty "=="
+  Ne -> pretty "!="
+  And -> pretty "&"
+  Or -> pretty "|"
+  Xor -> pretty "^"
+  ShiftL -> pretty "<<"
+  ShiftR -> pretty ">>"
+  LAnd -> pretty "&&"
+  LOr -> pretty "||"
+  In -> pretty "in"
 
 ppFun :: [Param (Doc ann)] -> Doc ann -> Doc ann
 ppFun ps e = pfunction <> parens (commaSep ps') <+> e
@@ -293,24 +289,24 @@ ppFun ps e = pfunction <> parens (commaSep ps') <+> e
 ppMaybeDoc :: Maybe (Doc ann) -> Doc ann
 ppMaybeDoc = fromMaybe mempty
 
-instance Pretty Ann.Expr' where
-  pretty = pretty . forget'
+prettyExpr' :: Ann.Expr' -> Doc ann
+prettyExpr' = prettyFixExprF' . forget'
 
-instance Pretty (Fix ExprF') where
-  pretty = foldFix go
-    where
-      go = \case
-        InR (Const (Import fp)) -> pimport <+> squotes (pretty fp)
-        InL e -> ppExpr e
+prettyFixExprF' :: Fix ExprF' -> Doc ann
+prettyFixExprF' = foldFix go
+  where
+    go = \case
+      InR (Const (Import fp)) -> pimport <+> squotes (pretty fp)
+      InL e -> ppExpr e
 
-instance Pretty (Fix ExprF) where
-  pretty = foldFix ppExpr
+prettyFixExprF :: Fix ExprF -> Doc ann
+prettyFixExprF = foldFix ppExpr
 
-instance Pretty Ann.Expr where
-  pretty = pretty . forget'
+prettyExpr :: Ann.Expr -> Doc ann
+prettyExpr = prettyFixExprF . forget'
 
 ppArgs :: Args (Doc ann) -> Doc ann
-ppArgs (Args args strict) = parensSep comma (ppArg <$> args)
+ppArgs (Args args _) = parensSep comma (ppArg <$> args)
 
 ppArg :: Arg (Doc ann) -> Doc ann
 ppArg (Pos a) = a
@@ -319,11 +315,11 @@ ppArg (Named n a) = surround equals (pretty n) a
 ppCompSpec :: NonEmpty (CompSpec (Doc ann)) -> Doc ann
 ppCompSpec cs = hsep $ f <$> NE.toList cs
   where
-    f (CompSpec v f c) =
+    f (CompSpec v f' c) =
       pfor
         <+> pretty v
         <+> pin
-        <+> parens f
+        <+> parens f'
         <+> ppMaybeDoc ((pif <+>) <$> c)
 
 ppExpr :: ExprF (Doc ann) -> Doc ann
@@ -345,8 +341,8 @@ ppExpr = \case
   EAssert (Assert c m e) -> passert <+> c <> ppMaybeDoc ((colon <>) <$> m) <> semi <+> e
   EIndex a b -> parens a <> brackets b
   ELookup a i -> enclose a (pretty i) dot
-  EUnyOp o a -> parens (pretty o <> a)
-  EBinOp o a b -> parens (parens a <+> pretty o <+> parens b)
+  EUnyOp o a -> parens (prettyUnyOp o <> a)
+  EBinOp o a b -> parens (parens a <+> prettyBinOp o <+> parens b)
   ESlice a b e s -> parens a <> bracketSep colon (ppMaybeDoc <$> [b, e, s])
   EArrComp e cs -> lbracket <> e <+> ppCompSpec cs <> rbracket
   EObjComp f ls cs -> ppObject ls [ppField f <+> ppCompSpec cs]

--- a/src/Language/Jsonnet/Syntax.hs
+++ b/src/Language/Jsonnet/Syntax.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-partial-fields #-}
 -- |
 -- Module                  : Language.Jsonnet.Syntax
 -- Copyright               : (c) 2020-2021 Alexandre Moreno
@@ -9,7 +10,6 @@ module Language.Jsonnet.Syntax where
 
 import Control.Applicative (Const (..))
 import Data.Data (Data)
-import Data.Eq.Deriving
 import Data.Functor.Classes
 import Data.Functor.Classes.Generic
 import Data.Functor.Sum

--- a/src/Language/Jsonnet/Syntax/Annotated.hs
+++ b/src/Language/Jsonnet/Syntax/Annotated.hs
@@ -9,8 +9,6 @@ module Language.Jsonnet.Syntax.Annotated where
 
 import Data.Fix
 import Data.Functor.Sum
-import Data.List.NonEmpty
-import Data.Semigroup.Foldable
 import Language.Jsonnet.Annotate
 import Language.Jsonnet.Common
 import Language.Jsonnet.Parser.SrcSpan

--- a/src/Language/Jsonnet/TH.hs
+++ b/src/Language/Jsonnet/TH.hs
@@ -10,26 +10,19 @@
 module Language.Jsonnet.TH where
 
 import Control.Monad ((>=>))
-import Control.Monad.Except hiding (lift)
-import Data.Binary (Binary, encode)
+import Control.Monad.Except
+import Data.Binary (encode)
 import Data.Data
-import Data.Functor.Product
-import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Instances.TH.Lift ()
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import Language.Jsonnet.Annotate (forget)
-import Language.Jsonnet.Common
-import Language.Jsonnet.Core
 import Language.Jsonnet.Desugar
 import qualified Language.Jsonnet.Parser as Parser
-import Language.Jsonnet.Parser.SrcSpan
-import Language.Jsonnet.Pretty ()
-import Language.Jsonnet.Syntax
+import Language.Jsonnet.Pretty (prettyError)
 import Language.Jsonnet.Syntax.Annotated
-import Prettyprinter (pretty)
 
 liftText :: Text -> Q Exp
 liftText txt = AppE (VarE 'T.pack) <$> lift (T.unpack txt)
@@ -41,7 +34,7 @@ liftDataWithText = dataToExpQ (fmap liftText . cast)
 parse0 :: FilePath -> Text -> Q Expr
 parse0 path str = do
   parse' str >>= \case
-    Left err -> fail (show $ pretty err)
+    Left err -> fail (show $ prettyError err)
     Right res -> pure res
   where
     parse' =

--- a/test/Language/Jsonnet/Test/Golden.hs
+++ b/test/Language/Jsonnet/Test/Golden.hs
@@ -4,40 +4,28 @@
 -- |
 module Language.Jsonnet.Test.Golden where
 
-import Control.Monad
-import Control.Monad.Except
 import qualified Data.ByteString.Lazy as LBS
-import Data.IORef
 import qualified Data.Map.Strict as M
-import qualified Data.Text as T
 import qualified Data.Text.IO as T (readFile)
 import Data.Text.Lazy
 import Data.Text.Lazy.Encoding (encodeUtf8)
 import Language.Jsonnet hiding (extVars)
-import Language.Jsonnet.Annotate
-import Language.Jsonnet.Desugar
-import Language.Jsonnet.Error
-import Language.Jsonnet.Eval
-import Language.Jsonnet.Eval.Monad
-import Language.Jsonnet.Pretty ()
-import qualified Language.Jsonnet.Std.Lib as Lib
-import Language.Jsonnet.Std.TH (mkStdlib)
+import Language.Jsonnet.Pretty (ppJson, prettyError)
 import Language.Jsonnet.Value
-import Prettyprinter (Pretty, pretty)
+import Prettyprinter (Doc)
 import System.FilePath (replaceExtension, takeBaseName)
 import System.IO.Unsafe (unsafePerformIO)
-import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (findByExtension, goldenVsString)
-import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 
-render :: Pretty a => a -> LBS.ByteString
-render = encodeUtf8 . pack . show . pretty
+render :: (a -> Doc ann) -> a -> LBS.ByteString
+render printer = encodeUtf8 . pack . show . printer
 
 run :: Config -> IO LBS.ByteString
 run conf = do
   prog <- T.readFile (fname conf)
   outp <- interpret conf prog
-  pure (either render render outp)
+  pure (either (render prettyError) (render (ppJson 4)) outp)
 
 -- Adapted from the C++ test suite
 extVars :: ExtVars

--- a/test/Language/Jsonnet/Test/Roundtrip.hs
+++ b/test/Language/Jsonnet/Test/Roundtrip.hs
@@ -18,7 +18,6 @@ import Language.Jsonnet.Syntax
 import Prettyprinter
 import Prettyprinter.Render.Text
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
 import Test.Tasty.Hedgehog
 
 genString :: Gen String
@@ -97,7 +96,7 @@ genLiteral =
   Gen.choice
     [ pure (Fix mkNullF),
       Fix . mkBoolF <$> Gen.bool,
-      Fix . mkIntF <$> Gen.integral (Range.linear 0 10),
+      Fix . mkIntF @Int <$> Gen.integral (Range.linear 0 10),
       genLitStr
     ]
 
@@ -181,7 +180,7 @@ printExpr :: Fix ExprF' -> Text
 printExpr =
   renderStrict
     . layoutPretty defaultLayoutOptions
-    . pretty
+    . prettyFixExprF'
 
 parseExpr :: Text -> Either Error (Fix ExprF')
 parseExpr = fmap forget' . Parser.parse ""
@@ -192,6 +191,7 @@ prop_roundtrip =
     x <- forAll genExpr
     tripping x printExpr parseExpr
 
+testRoundtripGroup :: TestTree
 testRoundtripGroup =
   testGroup
     "Property tests"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,14 +1,9 @@
 -- |
 module Main where
 
-import Hedgehog
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 import Language.Jsonnet.Test.Golden
 import Language.Jsonnet.Test.Roundtrip
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
-import Test.Tasty.Hedgehog
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This PR enables a sensible set of warnings for all components in the Cabal package. Almost all the warnings that arise from this change are fixed. A minority of them are disabled locally per module (e.g. some orphan instance warnings which would require non-trivial amount of code reshuffling to fix). I believe enabling the warnings also uncovered a few issues with the current code; mostly some non-exhaustive pattern matches. I tried to fix most of these as part of a separate commit (2f2ab60e883784d3fc046a906f12511ed278cce4), since they include semantic changes and requires greater care in review. There are only a select few warnings remaining in the code, which would require deeper domain knowledge to fix; those that I did not feel very comfortable about.